### PR TITLE
Fix b/strong color

### DIFF
--- a/static/dark.css
+++ b/static/dark.css
@@ -17,6 +17,10 @@
 		box-shadow: none !important;
 	}
 
+	b, strong {
+		color: #B8C3CC;
+	}
+	
 	span.divider {
 		background-color: #2B343B;
 	}


### PR DESCRIPTION
Titles are too dark. This PR sets the color to the same color from links in the topbar.

<img width="754" alt="Screen Shot 2021-12-21 at 00 34 46" src="https://user-images.githubusercontent.com/139272/146846617-4cb0bd6a-2246-4ac3-96d8-d53845f3b309.png">

<img width="680" alt="Screen Shot 2021-12-21 at 00 35 06" src="https://user-images.githubusercontent.com/139272/146846626-ae00cad3-922a-4e6a-83b5-6c27b9e5a2b4.png">

